### PR TITLE
gcip now prevents naming conflicts when adding jobs to the pipeline. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added config.yml to .github dir to force using issue templates.
 * Added gitlab_ci_environment_variables monkeypatch fixture. It allows patching environment variables.
 * Added gitlab_ci_environmnet_variables fixture to tests.
+* The gcip is now able to detect if two or more jobs would have the same name in the rendered pipeline
+  and raises an ValueError to prevent undesirable pipeline behavior.
 
 ### Changed
 

--- a/docs/user/index.adoc
+++ b/docs/user/index.adoc
@@ -204,7 +204,7 @@ Rendering this pipeline leads to an error:
 
 [source]
 ----
-ValueError: NAMING CONFLICT: Two jobs have the same name 'do-something' when rendering the pipeline.
+JobNameConflictError: Two jobs have the same name 'do-something' when rendering the pipeline.
 Please fix this by providing a different name and/or namespace when adding those jobs to their sequences/pipeline.
 ----
 

--- a/docs/user/index.adoc
+++ b/docs/user/index.adoc
@@ -20,11 +20,11 @@ For the code documentation please proceed to the xref:./gcip/README.adoc[README.
 Your Gitlab project needs these two files:
 
 [source]
-____
+----
 MyProject
 ├ .gitlab-ci.py
 └ .gitlab-ci.yml
-____
+----
 
 The  `.gitlab-ci.yml` is the file you already know. It's only task is to
 render and trigger the child Pipeline created with the Gitlab CI Python Library.
@@ -193,31 +193,28 @@ include::../../tests/unit/comparison_files/test_readme_pipelines_are_sequences_t
 
 == Namespaces allow reuse of jobs and sequences
 
-Assume you want to reuse a parameterized job. Following link:./tests/unit/test_readme_missing_namespace.py[Input] is an *incorrect* example:
+Assume you want to reuse a parameterized job. Following code shows an *incorrect* example:
 
 [source,python]
 ----
 include::../../tests/unit/test_readme_missing_namespace.py[]
 ----
 
-The output is obviously *wrong* as we expect two jobs but just get one:
+Rendering this pipeline leads to an error:
 
-[source,yaml]
+[source]
 ----
-include::../../tests/unit/comparison_files/test_readme_missing_namespace_test.yml[]
+ValueError: NAMING CONFLICT: Two jobs have the same name 'do-something' when rendering the pipeline.
+Please fix this by providing a different name and/or namespace when adding those jobs to their sequences/pipeline.
 ----
 
-This is because both jobs were added with an identical name to the pipeline. The second job will
+This is because both jobs were added with an identical name to the pipeline. The second job would
 overwrite the first one.
 
-When adding jobs or sequences to a sequence with
-
-* `+.add_jobs(...)+`
-* `+.add_sequences(...)+`
-
-both methods accept the `namespace` parameter, you should use to modify the name of the jobs added.
-The value of `namespaces` will be appended to the jobs `name` and `stage`. This only applies to
-the jobs (sequences) added but not to the jobs (and sequences) already contained in the sequence.
+When adding jobs or sequences to a sequence, the `.add_children()`  method accepts the `namespace` parameter,
+you should use to modify the name of the jobs added. The value of `namespaces` will be appended to the jobs
+`name` and `stage`. This only applies to the jobs (sequences) added but not to the jobs (and sequences) already
+contained in the sequence.
 
 === Reuse jobs
 
@@ -355,6 +352,7 @@ As output we get two services updated in parallel but in consecutive stages.
 ----
 include::../../tests/unit/comparison_files/test_readme_mix_namespace_and_name_test.yml[]
 ----
+
 
 == Batteries included
 

--- a/gcip/__init__.py
+++ b/gcip/__init__.py
@@ -83,7 +83,10 @@ from .core.include import (  # noqa
 )
 from .core.service import Service  # noqa
 # yapf: disable
-from .core.pipeline import Pipeline  # noqa
+from .core.pipeline import (  # noqa
+    Pipeline,
+    JobNameConflictError,
+)
 from .core.sequence import Sequence  # noqa
 from .core.variables import PredefinedVariables  # noqa
 

--- a/gcip/core/pipeline.py
+++ b/gcip/core/pipeline.py
@@ -76,6 +76,13 @@ class Pipeline(Sequence):
 
         pipeline["stages"] = list(stages.keys())
         for job in job_copies:
+            if job.name in pipeline:
+                raise ValueError(
+                    f"NAMING CONFLICT: Two jobs have the same name '{job.name}' when rendering the pipeline."
+                    "\nPlease fix this by providing a different name and/or namespace when adding those jobs to"
+                    " their sequences/pipeline."
+                )
+
             pipeline[job.name] = job.render()
         return pipeline
 

--- a/gcip/core/sequence.py
+++ b/gcip/core/sequence.py
@@ -30,11 +30,40 @@ class ChildDict(TypedDict):
     """This data structure is supposed to store one child of a `Sequence` with all required information about that child."""
 
     child: Union[Job, Sequence]
+    """The child to store - a `gcip.core.job.Job` or `Sequence`."""
     namespace: Optional[str]
+    """The namespace with whom the `child` was added to the `Sequence`."""
     name: Optional[str]
+    """The name with whom the `child` was added to the `Sequence`."""
 
 
 class Sequence():
+    """A Sequence collects multiple `gcip.core.job.Job`s and/or other `Sequence`s into a group.
+
+    This concept is no official representation of a Gitlab CI keyword. But it is such a powerful
+    extension of the Gitlab CI core funtionality and an essential building block of the gcip, that
+    it is conained in the `gcip.core` module.
+
+    A Sequence offers a mostly similar interface like `gcip.core.job.Job`s that allows to modify
+    all Jobs and child Sequences contained into that parent Sequence. For example: Instad of calling
+    `add_tag()` on a dozens of Jobs you can call `add_tag()` on the sequence that contain those Jobs.
+    The tag will then be applied to all Jobs in that Sequence and recursively to all Jobs within child
+    Sequenes of that Sequence.
+
+    Sequences must be added to a `gcip.core.pipeline.Pipeline`, either directly or as part of other Sequences.
+    That means Sequences are not meant to be a throw away configuration container for a bunch ob Jobs.
+    This is because adding a Job to a Sequence creates a copy of that Job, which will be inderectly added to
+    the `Pipeline` by that Sequence. Not adding that Sequence to a Pipeline means also not adding its Jobs
+    to the Pipeline. If other parts of the Pipeline have dependencies to those Jobs, they will be broken.
+
+    As said before, adding a Job to a Sequence creates copies of that Job. To void conflicts between Jobs,
+    you should set `name` and/or `namespace` when adding the job (or child sequence). The sequence will add
+    the `name` / `namespace` to the ones of the Job, when rendering the pipeline. If you do not set those
+    identifiers, or you set equal name/namespaces for jobs and sequences, you provoke having two or more
+    jobs having the same name in the pipeline. The gcip will raise a ValueError, to avoid unexpected
+    pipeline behavior. You can read more information in the chapter "Namespaces allow reuse of jobs
+    and sequences" of the user documantation.
+    """
     def __init__(self) -> None:
         super().__init__()
         self._children: List[ChildDict] = list()

--- a/gcip/core/sequence.py
+++ b/gcip/core/sequence.py
@@ -1,3 +1,29 @@
+"""A Sequence collects multiple `gcip.core.job.Job`s and/or other `Sequence`s into a group.
+
+This concept is no official representation of a Gitlab CI keyword. But it is such a powerful
+extension of the Gitlab CI core funtionality and an essential building block of the gcip, that
+it is conained in the `gcip.core` module.
+
+A Sequence offers a mostly similar interface like `gcip.core.job.Job`s that allows to modify
+all Jobs and child Sequences contained into that parent Sequence. For example: Instad of calling
+`add_tag()` on a dozens of Jobs you can call `add_tag()` on the sequence that contain those Jobs.
+The tag will then be applied to all Jobs in that Sequence and recursively to all Jobs within child
+Sequenes of that Sequence.
+
+Sequences must be added to a `gcip.core.pipeline.Pipeline`, either directly or as part of other Sequences.
+That means Sequences are not meant to be a throw away configuration container for a bunch ob Jobs.
+This is because adding a Job to a Sequence creates a copy of that Job, which will be inderectly added to
+the `Pipeline` by that Sequence. Not adding that Sequence to a Pipeline means also not adding its Jobs
+to the Pipeline. If other parts of the Pipeline have dependencies to those Jobs, they will be broken.
+
+As said before, adding a Job to a Sequence creates copies of that Job. To void conflicts between Jobs,
+you should set `name` and/or `namespace` when adding the job (or child sequence). The sequence will add
+the `name` / `namespace` to the ones of the Job, when rendering the pipeline. If you do not set those
+identifiers, or you set equal name/namespaces for jobs and sequences, you provoke having two or more
+jobs having the same name in the pipeline. The gcip will raise a ValueError, to avoid unexpected
+pipeline behavior. You can read more information in the chapter "Namespaces allow reuse of jobs
+and sequences" of the user documantation.
+"""
 from __future__ import annotations
 
 import copy
@@ -38,32 +64,7 @@ class ChildDict(TypedDict):
 
 
 class Sequence():
-    """A Sequence collects multiple `gcip.core.job.Job`s and/or other `Sequence`s into a group.
-
-    This concept is no official representation of a Gitlab CI keyword. But it is such a powerful
-    extension of the Gitlab CI core funtionality and an essential building block of the gcip, that
-    it is conained in the `gcip.core` module.
-
-    A Sequence offers a mostly similar interface like `gcip.core.job.Job`s that allows to modify
-    all Jobs and child Sequences contained into that parent Sequence. For example: Instad of calling
-    `add_tag()` on a dozens of Jobs you can call `add_tag()` on the sequence that contain those Jobs.
-    The tag will then be applied to all Jobs in that Sequence and recursively to all Jobs within child
-    Sequenes of that Sequence.
-
-    Sequences must be added to a `gcip.core.pipeline.Pipeline`, either directly or as part of other Sequences.
-    That means Sequences are not meant to be a throw away configuration container for a bunch ob Jobs.
-    This is because adding a Job to a Sequence creates a copy of that Job, which will be inderectly added to
-    the `Pipeline` by that Sequence. Not adding that Sequence to a Pipeline means also not adding its Jobs
-    to the Pipeline. If other parts of the Pipeline have dependencies to those Jobs, they will be broken.
-
-    As said before, adding a Job to a Sequence creates copies of that Job. To void conflicts between Jobs,
-    you should set `name` and/or `namespace` when adding the job (or child sequence). The sequence will add
-    the `name` / `namespace` to the ones of the Job, when rendering the pipeline. If you do not set those
-    identifiers, or you set equal name/namespaces for jobs and sequences, you provoke having two or more
-    jobs having the same name in the pipeline. The gcip will raise a ValueError, to avoid unexpected
-    pipeline behavior. You can read more information in the chapter "Namespaces allow reuse of jobs
-    and sequences" of the user documantation.
-    """
+    """A Sequence collects multiple `gcip.core.job.Job`s and/or other `Sequence`s into a group."""
     def __init__(self) -> None:
         super().__init__()
         self._children: List[ChildDict] = list()

--- a/tests/unit/test_readme_missing_namespace.py
+++ b/tests/unit/test_readme_missing_namespace.py
@@ -1,5 +1,6 @@
+import pytest
+
 import gcip
-from tests import conftest
 
 
 def job_for(environment: str) -> gcip.Job:
@@ -11,4 +12,5 @@ def test():
     for env in ["development", "test"]:
         pipeline.add_children(job_for(env))
 
-    conftest.check(pipeline.render())
+    with pytest.raises(ValueError, match="NAMING CONFLICT: Two jobs have the same name"):
+        pipeline.render()

--- a/tests/unit/test_readme_missing_namespace.py
+++ b/tests/unit/test_readme_missing_namespace.py
@@ -1,16 +1,16 @@
 import pytest
 
-import gcip
+from gcip import Job, Pipeline, JobNameConflictError
 
 
-def job_for(environment: str) -> gcip.Job:
-    return gcip.Job(namespace="do_something", script=f"./do-something-on.sh {environment}")
+def job_for(environment: str) -> Job:
+    return Job(namespace="do_something", script=f"./do-something-on.sh {environment}")
 
 
 def test():
-    pipeline = gcip.Pipeline()
+    pipeline = Pipeline()
     for env in ["development", "test"]:
         pipeline.add_children(job_for(env))
 
-    with pytest.raises(ValueError, match="NAMING CONFLICT: Two jobs have the same name"):
+    with pytest.raises(JobNameConflictError):
         pipeline.render()


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

On rendering the gcip checks if two or more jobs would have the same name in the pipeline and raise an error if so. This helps the user to prevent naming conflicts with undesirable pipeline behavior.

Was the change discussed in an issue?
------------------------------------------------------------


Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/dbsystel/gitlab-ci-python-library/blob/main/CONTRIBUTING.md)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added api documentation for the changes
- [x] I added a changelog entry to the unreleased section with the PR number. [Changelog](https://github.com/dbsystel/gitlab-ci-python-library/blob/main/CHANGELOG.md)
- [x] Linting is done, and linting jobs are successfull
- [x] I'm done, this Pull Request is ready for review
