### PR TITLE
make kaniko pytest independent from the pipeline it runs at

### DIFF
--- a/tests/unit/comparison_files/test_kaniko_test_default_kaniko_job.yml
+++ b/tests/unit/comparison_files/test_kaniko_test_default_kaniko_job.yml
@@ -10,6 +10,6 @@ execute-kaniko:
   - mkdir -p /kaniko/.docker && echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"$DOCKER_USER\",\"password\":\"$DOCKER_LOGIN\"}}}"
     > /kaniko/.docker/config.json
   - date
-  - executor --context /path/to/project --dockerfile /path/to/project/Dockerfile --no-push
-    --destination thomass/gcip:my-awsome-feature-branch
+  - executor --context /path/to/project --dockerfile /path/to/project/Dockerfile --destination
+    thomass/gcip:my-awsome-feature-branch
   - rm -rf /kaniko/.docker/config.json

--- a/tests/unit/test_kaniko.py
+++ b/tests/unit/test_kaniko.py
@@ -1,4 +1,4 @@
-from gcip import Pipeline, PredefinedVariables
+from gcip import Pipeline
 from tests import conftest
 from gcip.addons.kaniko import jobs as kaniko
 
@@ -9,7 +9,7 @@ def test_default_kaniko_job(gitlab_ci_environment_variables):
     pipeline.add_children(
         kaniko.execute(
             image_name="thomass/gcip",
-            enable_push=(PredefinedVariables.CI_COMMIT_TAG or PredefinedVariables.CI_COMMIT_BRANCH == "main"),
+            enable_push=True,
             registry_user_env_var="DOCKER_USER",
             registry_login_env_var="DOCKER_LOGIN",
         ),


### PR DESCRIPTION
minor pytest fix