### PR TITLE
Added new `class` which handels docker client config and renders it t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved conftest.check() function. It tells the user how to create comparison files if the file not found exception.
 * Improved `conftest.check()` function. Now AssertionError is handled, the user will get receive how to update comparison files.
 * Added new class `PredefinedImages` in `gcip.addons.container`. Allows access to container images, that are widley used.
-
 * Added new `class` which handels docker client config and renders it to a json string.
+
 ### Changed
 
 * **BREAKING** Renamed all occurences of 'job\w*sequence' to 'sequence'. Mainly this renames

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved `conftest.check()` function. Now AssertionError is handled, the user will get receive how to update comparison files.
 * Added new class `PredefinedImages` in `gcip.addons.container`. Allows access to container images, that are widley used.
 
+* Added new `class` which handels docker client config and renders it to a json string.
 ### Changed
 
 * **BREAKING** Renamed all occurences of 'job\w*sequence' to 'sequence'. Mainly this renames

--- a/gcip/addons/container/config.py
+++ b/gcip/addons/container/config.py
@@ -13,7 +13,7 @@ cfg.render()
 This will render a Client configuration and dumps it as a json string.
 """
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 DockerConfig = Dict[str, Any]
 
@@ -117,7 +117,7 @@ class DockerClientConfig():
         """
         self.config.update(raw_input)
 
-    def render(self) -> str:
+    def get_shell_command(self) -> List[str]:
         """
         Renders the shell command for creating the docker client config.
 
@@ -126,7 +126,8 @@ class DockerClientConfig():
         destinatino e.g. ~/.docker/config.json. This ensures, that environment variables are substituted.
 
         Returns:
-            str: Docker client configuration as a JSON string.
+            list:  Returns a list with `mkdir -p config_file_path` and a shell escaped JSON string
+                echoed to `config_file_path`/`config_file_name`
         """
         script = [
             f"mkdir -p {self._config_file_path}",

--- a/gcip/addons/container/config.py
+++ b/gcip/addons/container/config.py
@@ -1,0 +1,122 @@
+"""This module represents a Docker client configuration.
+
+Example:
+
+```
+from gcip.addons.container.config import DockerClientConfig
+
+cfg = DockerClientConfig()
+cfg.add_cred_helper("1234567890.dkr.ecr.us-east-1.amazonaws.com", "ecr-login")
+cfg.render()
+```
+
+This will render a Client configuration and dumps it as a json string.
+"""
+import json
+from typing import Any, Dict
+
+DockerConfig = Dict[str, Any]
+
+
+class DockerClientConfig():
+    def __init__(self) -> None:
+        """
+        Class which represents a docker client configuration.
+
+        The configuration is mostly found unde $HOME/.docker/config.json.
+        """
+        self.config: DockerConfig = {}
+
+    def set_creds_store(self, creds_store: str) -> None:
+        """
+        Sets the `credsStore` setting for clients.
+        See [docker login#credentials-store](https://docs.docker.com/engine/reference/commandline/login/#credentials-store)
+
+        Be aware, that if you set the `credsStore` and add creds_helper or
+        username and password authentication, those authentication methods
+        are not used.
+
+        Clients which can authenticate against a registry can handle the credential
+        store itself, mostly you do not want to set the `credsStore`.
+        Use `credsHelpers` instead.
+
+        Args:
+            creds_store (str): Should be the suffix of the program to use
+            (i.e. everything after docker-credential-).
+            For example `osxkeychain`, to use docker-credential-osxkeychain or
+            `ecr-login`, to use docker-crendential-ecr-login
+        """
+        self.config["credsStore"] = creds_store
+
+    def add_cred_helper(self, registry: str, cred_helper: str) -> None:
+        """
+        Adds a Credentials helper `credHelpers` for a registry.
+        See [docker login#credential-helpers](https://docs.docker.com/engine/reference/commandline/login/#credential-helpers)
+
+        Args:
+            registry (str): Name of the container registry to set `creds_helper` for.
+            cred_helper (str): Name of the credential helper to use together with the `registry`.
+        """
+        compose = {
+            registry: cred_helper
+        }
+        if "credsHelpers" not in self.config.keys():
+            self.config["credHelpers"] = compose
+        else:
+            self.config["credHelpers"].update(compose)
+
+    def add_auths(
+        self,
+        registry: str,
+        username_env_var: str = "REGISTRY_USERNAME",
+        password_env_var: str = "REGISTRY_PASSWORD",
+    ) -> None:
+        """
+        Adds basic authentication `auths` setting to the configuration.
+
+        This method acts a little special, because of some security aspects.
+        The method, takse three arguments, `registry`, `username_env_var` and `password_env_var`.
+        Arguments ending wit *_env_var, are ment to be available as a `gcip.Job` variable.
+
+        Args:
+            registry (str): Name of the container registry to set `creds_helper` for.
+            username_env_var (str): Name of the environment variable which as the registry username stored. Defaults to REGISTRY_USERNAME.
+            password_env_var (str): Name of the environment variable which as the registry password stored. Defaults to REGISTRY_PASSWORD.
+        """
+        compose = {
+            registry: {
+                "username": "$" + username_env_var,
+                "password": "$" + password_env_var
+            }
+        }
+
+        if "auths" not in self.config.keys():
+            self.config["auths"] = compose
+        else:
+            self.config["auths"].update(compose)
+
+    def add_raw(self, raw_input: Dict[Any, Any]) -> None:
+        """
+        Adds arbitrary settings to configuration.
+
+        Be aware and warned! You can overwrite any predefined settings with this method.
+        This method is intendet to be used, if non suitable method is available and you
+        have to set a configuration setting.
+
+        Args:
+            raw_input (Dict[Any, Any]): Dictionary of non-available settings to be set.
+        """
+        self.config.update(raw_input)
+
+    def render(self) -> str:
+        """
+        Renders the settings of the docker client config.
+
+        The render method uses `json.dumps()` to dump the configuration as a json string.
+        In Jobs which needed the configuration the renderd output should be redirected to the appropriate
+        destinatino e.g. ~/.docker/config.json. This ensures, that environment variables are substituted.
+
+        Returns:
+            str: Docker client configuration as a JSON string.
+        """
+        return json.dumps(self.config)

--- a/gcip/addons/container/config.py
+++ b/gcip/addons/container/config.py
@@ -74,7 +74,7 @@ class DockerClientConfig():
         else:
             self.config["credHelpers"].update(compose)
 
-    def add_auths(
+    def add_auth(
         self,
         registry: str,
         username_env_var: str = "REGISTRY_USERNAME",
@@ -119,7 +119,7 @@ class DockerClientConfig():
 
     def render(self) -> str:
         """
-        Renders the settings of the docker client config.
+        Renders the shell command for creating the docker client config.
 
         The render method uses `json.dumps()` to dump the configuration as a json string and escapes it for the shell.
         In Jobs which needed the configuration the renderd output should be redirected to the appropriate

--- a/tests/unit/comparison_files/test_addons_container_config_test_complex_docker_client_config.yml
+++ b/tests/unit/comparison_files/test_addons_container_config_test_complex_docker_client_config.yml
@@ -1,3 +1,5 @@
-'{"auths": {"index.docker.com": {"username": "$CUSTOM_DOCKER_USER", "password": "$CUSTOM_DOCKER_PW"}},
-  "credHelpers": {"123456789.dkr.ecr.eu-central-1.amazonaws.com": "ecr-login"}, "credsStore":
-  "gcr", "proxies": {"default": {"httpProxy": "127.0.0.1:1234"}}}'
+- mkdir -p $HOME/.docker/
+- 'echo "{\"auths\": {\"index.docker.com\": {\"username\": \"$CUSTOM_DOCKER_USER\",
+  \"password\": \"$CUSTOM_DOCKER_PW\"}}, \"credHelpers\": {\"123456789.dkr.ecr.eu-central-1.amazonaws.com\":
+  \"ecr-login\"}, \"credsStore\": \"gcr\", \"proxies\": {\"default\": {\"httpProxy\":
+  \"127.0.0.1:1234\"}}}" > $HOME/.docker/config.json'

--- a/tests/unit/comparison_files/test_addons_container_config_test_complex_docker_client_config.yml
+++ b/tests/unit/comparison_files/test_addons_container_config_test_complex_docker_client_config.yml
@@ -1,0 +1,3 @@
+'{"auths": {"index.docker.com": {"username": "$CUSTOM_DOCKER_USER", "password": "$CUSTOM_DOCKER_PW"}},
+  "credHelpers": {"123456789.dkr.ecr.eu-central-1.amazonaws.com": "ecr-login"}, "credsStore":
+  "gcr", "proxies": {"default": {"httpProxy": "127.0.0.1:1234"}}}'

--- a/tests/unit/comparison_files/test_addons_container_config_test_docker_client_config.yml
+++ b/tests/unit/comparison_files/test_addons_container_config_test_docker_client_config.yml
@@ -1,1 +1,3 @@
-'{"auths": {"index.docker.com": {"username": "$REGISTRY_USERNAME", "password": "$REGISTRY_PASSWORD"}}}'
+- mkdir -p $HOME/.docker/
+- 'echo "{\"auths\": {\"index.docker.com\": {\"username\": \"$REGISTRY_USERNAME\",
+  \"password\": \"$REGISTRY_PASSWORD\"}}}" > $HOME/.docker/config.json'

--- a/tests/unit/comparison_files/test_addons_container_config_test_docker_client_config.yml
+++ b/tests/unit/comparison_files/test_addons_container_config_test_docker_client_config.yml
@@ -1,0 +1,1 @@
+'{"auths": {"index.docker.com": {"username": "$REGISTRY_USERNAME", "password": "$REGISTRY_PASSWORD"}}}'

--- a/tests/unit/test_addons_container_config.py
+++ b/tests/unit/test_addons_container_config.py
@@ -1,0 +1,21 @@
+from tests import conftest
+from gcip.addons.container.config import DockerClientConfig
+
+
+def test_docker_client_config():
+    dcc = DockerClientConfig()
+    dcc.add_auths("index.docker.com")
+    conftest.check(dcc.render())
+
+
+def test_complex_docker_client_config():
+    dcc = DockerClientConfig()
+    dcc.add_auths("index.docker.com", "CUSTOM_DOCKER_USER", "CUSTOM_DOCKER_PW")
+    dcc.add_cred_helper("123456789.dkr.ecr.eu-central-1.amazonaws.com", "ecr-login")
+    dcc.set_creds_store("gcr")
+    dcc.add_raw({"proxies": {
+        "default": {
+            "httpProxy": "127.0.0.1:1234"
+        }
+    }})
+    conftest.check(dcc.render())

--- a/tests/unit/test_addons_container_config.py
+++ b/tests/unit/test_addons_container_config.py
@@ -4,13 +4,13 @@ from gcip.addons.container.config import DockerClientConfig
 
 def test_docker_client_config():
     dcc = DockerClientConfig()
-    dcc.add_auths("index.docker.com")
-    conftest.check(dcc.render())
+    dcc.add_auth("index.docker.com")
+    conftest.check(dcc.get_shell_command())
 
 
 def test_complex_docker_client_config():
     dcc = DockerClientConfig()
-    dcc.add_auths("index.docker.com", "CUSTOM_DOCKER_USER", "CUSTOM_DOCKER_PW")
+    dcc.add_auth("index.docker.com", "CUSTOM_DOCKER_USER", "CUSTOM_DOCKER_PW")
     dcc.add_cred_helper("123456789.dkr.ecr.eu-central-1.amazonaws.com", "ecr-login")
     dcc.set_creds_store("gcr")
     dcc.add_raw({"proxies": {
@@ -18,4 +18,4 @@ def test_complex_docker_client_config():
             "httpProxy": "127.0.0.1:1234"
         }
     }})
-    conftest.check(dcc.render())
+    conftest.check(dcc.get_shell_command())


### PR DESCRIPTION
…o a json string.

<!--Inspired by https://github.com/restic/restic-->

<!--
Thank you very much for contributing code or documentation to gcip! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The new class helps to handle the creation of docker client configuration within container jobs.
If you need e.g. multiple registries with authentication, you can add them through the class an render it to stdout.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue?
------------------------------------------------------------
<!--
Link issues.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/dbsystel/gitlab-ci-python-library/blob/main/CONTRIBUTING.md)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added api documentation for the changes
- [x] I added a changelog entry to the unreleased section with the PR number. [Changelog](https://github.com/dbsystel/gitlab-ci-python-library/blob/main/CHANGELOG.md)
- [x] Linting is done, and linting jobs are successfull
- [x] I'm done, this Pull Request is ready for review
