### PR TITLE
Changed deployment pipeline, using build.build_scan_push_image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
+
+RUN apk add --update-cache \
+    gcc musl-dev \
+  && rm -rf /var/cache/apk/*
 
 WORKDIR /usr/src/app
 

--- a/gitlabci-local.sh
+++ b/gitlabci-local.sh
@@ -10,7 +10,23 @@ then
 fi
 
 echo "Powerd by https://pypi.org/project/gitlabci-local/"
-gitlabci-local -p -e CI="true" -e CI_PROJECT_DIR="/builds/gitlab-ci-python-library" -e CI_COMMIT_REF_SLUG="gitlab-local-sh" && cat generated-config.yml && gitlabci-local -c generated-config.yml $@
+
+if [ -z $REGISTRY_USERNAME ]; then
+    read -p "Enter container registry user: " REGISTRY_USERNAME
+fi
+if [ -z $REGISTRY_PASSWORD ]; then
+    read -sp "Enter container registry password: " REGISTRY_PASSWORD
+fi
+gitlabci_local_envs="-e CI=true
+    -e CI_PROJECT_NAME=gitlab-ci-python-library
+    -e CI_PROJECT_DIR=/builds/gitlab-ci-python-library
+    -e CI_COMMIT_REF_SLUG=gitlab-local-sh
+    -e REGISTRY_USERNAME=${REGISTRY_USERNAME}
+    -e REGISTRY_PASSWORD=${REGISTRY_PASSWORD}"
+
+gitlabci-local -p $gitlabci_local_envs && \
+cat generated-config.yml && \
+gitlabci-local $gitlabci_local_envs -c generated-config.yml $@
 
 rm -rf generated-config.yml
 rm -rf dist


### PR DESCRIPTION
<!--Inspired by https://github.com/restic/restic-->

<!--
Thank you very much for contributing code or documentation to gcip! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Changes our release process from `kaniko.execute` to `build.build_scan_push_image`

Was the change discussed in an issue?
------------------------------------------------------------
<!--
Link issues.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/dbsystel/gitlab-ci-python-library/blob/main/CONTRIBUTING.md)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added api documentation for the changes
- [x] I added a changelog entry to the unreleased section with the PR number. [Changelog](https://github.com/dbsystel/gitlab-ci-python-library/blob/main/CHANGELOG.md)
- [x] Linting is done, and linting jobs are successfull
- [x] I'm done, this Pull Request is ready for review
